### PR TITLE
Return TEMPFAIL upon SERVFAIL

### DIFF
--- a/src/smilla
+++ b/src/smilla
@@ -374,9 +374,9 @@ class Smilla(Milter.Base):
             if result.rcode_str == 'serv fail':
                 syslog(LOG_ERR,
                        "%s: unbound SMIMEA lookup for '%s' "
-                       "returned SERVFAIL - letting go plaintext"
+                       "returned SERVFAIL - deferring"
                         % (self.getsymval("i"), recipient))
-                return Milter.CONTINUE
+                return Milter.TEMPFAIL
             if result.bogus:
                 syslog(LOG_ERR,
                        "%s: unbound SMIMEA lookup for '%s' "


### PR DESCRIPTION
Currently, the milter is not implemented in a downgrade-resistant manner. In particular, an attacker can induce SERVFAIL responses, e.g. by performing a DoS attack on the authoritative server for the _smimecert subdomain. This will cause outbound mail to remain unencrypted. It is therefore better to treat a SERVFAIL response like failed DNSSEC authentication.